### PR TITLE
Poet dbtablenames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: php
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+php:
+ - 5.6
+ - 7.0
+
+env:
+ global:
+  - MOODLE_BRANCH=MOODLE_31_STABLE
+
+ matrix:
+  - DB=pgsql
+  - DB=mysqli
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - cd ../..
+  - composer selfupdate
+  - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci dev-poet
+  - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+
+install:
+  - moodle-plugin-ci install
+
+script:
+  - moodle-plugin-ci phplint
+  - moodle-plugin-ci phpcpd
+  - moodle-plugin-ci phpmd
+  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci codechecker --standard poet
+  - moodle-plugin-ci csslint
+  - moodle-plugin-ci shifter
+  - moodle-plugin-ci jshint
+  - moodle-plugin-ci validate
+  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci behat
+  - moodle-plugin-ci phpunit --coverage-text

--- a/classes/client.php
+++ b/classes/client.php
@@ -170,7 +170,7 @@ class client extends \oauth2_client {
 
         $this->log_out(); // Remove previous token.
 
-        $record = $DB->get_record('msaccount_refresh_tokens', array("user_id" => $USER->id));
+        $record = $DB->get_record('local_msaccount_refresh_tokens', array("user_id" => $USER->id));
 
         if (!$record || !$record->refresh_token) {
             return false;
@@ -220,15 +220,15 @@ class client extends \oauth2_client {
     public function store_refresh_token($refreshtoken) {
         global $DB, $USER;
 
-        $record = $DB->get_record('msaccount_refresh_tokens', array("user_id" => $USER->id));
+        $record = $DB->get_record('local_msaccount_refresh_tokens', array("user_id" => $USER->id));
         if ($record) {
             $record->refresh_token = $refreshtoken;
-            $DB->update_record('msaccount_refresh_tokens', $record);
+            $DB->update_record('local_msaccount_refresh_tokens', $record);
         } else {
             $record = new \stdClass();
             $record->user_id = $USER->id;
             $record->refresh_token = $refreshtoken;
-            $DB->insert_record('msaccount_refresh_tokens', $record);
+            $DB->insert_record('local_msaccount_refresh_tokens', $record);
         }
     }
 

--- a/classes/client.php
+++ b/classes/client.php
@@ -170,7 +170,7 @@ class client extends \oauth2_client {
 
         $this->log_out(); // Remove previous token.
 
-        $record = $DB->get_record('local_msaccount_refresh_tokens', array("user_id" => $USER->id));
+        $record = $DB->get_record('local_msaccount_ref_tokens', array("user_id" => $USER->id));
 
         if (!$record || !$record->refresh_token) {
             return false;
@@ -220,15 +220,15 @@ class client extends \oauth2_client {
     public function store_refresh_token($refreshtoken) {
         global $DB, $USER;
 
-        $record = $DB->get_record('local_msaccount_refresh_tokens', array("user_id" => $USER->id));
+        $record = $DB->get_record('local_msaccount_ref_tokens', array("user_id" => $USER->id));
         if ($record) {
             $record->refresh_token = $refreshtoken;
-            $DB->update_record('local_msaccount_refresh_tokens', $record);
+            $DB->update_record('local_msaccount_ref_tokens', $record);
         } else {
             $record = new \stdClass();
             $record->user_id = $USER->id;
             $record->refresh_token = $refreshtoken;
-            $DB->insert_record('local_msaccount_refresh_tokens', $record);
+            $DB->insert_record('local_msaccount_ref_tokens', $record);
         }
     }
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -4,7 +4,7 @@
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
   <TABLES>
-    <TABLE NAME="msaccount_refresh_tokens" COMMENT="to store Microsoft Account refresh tokens for users">
+    <TABLE NAME="local_msaccount_refresh_tokens" COMMENT="to store Microsoft Account refresh tokens for users">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="user_id" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="user id"/>

--- a/db/install.xml
+++ b/db/install.xml
@@ -4,7 +4,7 @@
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
   <TABLES>
-    <TABLE NAME="local_msaccount_refresh_tokens" COMMENT="to store Microsoft Account refresh tokens for users">
+    <TABLE NAME="local_msaccount_ref_tokens" COMMENT="to store Microsoft Account refresh tokens for users">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="user_id" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="user id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -69,5 +69,18 @@ function xmldb_local_msaccount_upgrade($oldversion) {
     // Moodle v2.7.0 release upgrade line.
     // Put any upgrade step following this.
 
+    // Moodle v3.1.0 release upgrade line.
+    // Put any upgrade step following this.
+    if ($oldversion < 2016062001) {
+        // Define table to be modified.
+        $table = new xmldb_table('msaccount_refresh_tokens');
+
+        // Rename the table to use the correct Moodle naming convention.
+        $dbman->rename_table($table, 'local_msaccount_refresh_tokens');
+
+        // Msaccount savepoint reached.
+        upgrade_plugin_savepoint(true, 2016062001, 'local', 'msaccount');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -82,5 +82,16 @@ function xmldb_local_msaccount_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2016062001, 'local', 'msaccount');
     }
 
+    if ($oldversion < 2016062002) {
+        // Define table to be modified.
+        $table = new xmldb_table('local_msaccount_refresh_tokens');
+
+        // Rename the table to use the correct Moodle naming convention.
+        $dbman->rename_table($table, 'local_msaccount_ref_tokens');
+
+        // Msaccount savepoint reached.
+        upgrade_plugin_savepoint(true, 2016062002, 'local', 'msaccount');
+    }
+
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2016062000;
+$plugin->version = 2016062001;
 $plugin->requires = 2016052300;
 $plugin->component = 'local_msaccount';
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2016062001;
+$plugin->version = 2016062002;
 $plugin->requires = 2016052300;
 $plugin->component = 'local_msaccount';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Moodle requires table names to be no longer than 28 characters. This pull fixes that problem.
